### PR TITLE
Referring to ibc_conditions.tsv instead of conditions.tsv

### DIFF
--- a/ibc_data/README.md
+++ b/ibc_data/README.md
@@ -14,10 +14,11 @@
 	* column named as *description* - description of the contrast
 	* column named as *tags* - list of cognitive components describing functional activity of the contrast
 
-* __conditions.tsv__ contains the list of all independent (or elementary) contrasts. They are formed by the elementary conditions *vs.* baseline. It is organized as follows:  
+* __ibc_conditions.tsv__ contains the list of all independent (or elementary) conditions for each task. They are formed by the elementary conditions *vs.* baseline. It is organized as follows:  
 
 	* column named as *task* - id of the task
-	* column named as *contrast* - id of the contrast referring to the elementary condition
+	* column named as *condition* - id referring to the elementary condition
+	* column named as *description* - short explanation of the elementary condition
 	
 ## Main *versus* All contrasts
 __main_contrasts.tsv__ contains only the contrasts isolating effects-of-interest. Most of the IBC tasks refer to categorical designs. Therefore, "main contrasts" are defined in terms of one of the following options: (1) "active condition *vs.* control condition"; (2) "control condition *vs.* baseline"; and, sometimes, (3) "active condition *vs.* baseline". For the few tasks that follow a parametric design, a "main contrast" can also be considered as "the parametric effect of the constant effect in the active condition *vs.* baseline". Importantly, main contrasts within tasks are linearly independent between them and, consequently, this also stands true across tasks.

--- a/ibc_public/utils_data.py
+++ b/ibc_public/utils_data.py
@@ -33,7 +33,7 @@ SUBJECTS = ['sub-%02d' % i for i in
 _package_directory = os.path.dirname(os.path.abspath(__file__))
 # Useful for the very simple examples
 CONDITIONS = pd.read_csv(os.path.join(
-    _package_directory, '..', 'ibc_data', 'conditions.tsv'), sep='\t')
+    _package_directory, '..', 'ibc_data', 'ibc_conditions.tsv'), sep='\t')
 CONTRASTS = pd.read_csv(os.path.join(
     _package_directory, '..', 'ibc_data', 'main_contrasts.tsv'), sep='\t')
 ALL_CONTRASTS = os.path.join(
@@ -315,7 +315,7 @@ def data_parser(derivatives=DERIVATIVES, conditions=CONDITIONS,
 
     # fixed-effects activation images (postprocessed)
     con_df = conditions
-    contrast_name = con_df.contrast
+    contrast_name = con_df.condition
 
     acq_card = '*' # if acquisition == 'all'
     if acquisition in ['ffx', 'ap', 'pa']:
@@ -592,7 +592,7 @@ def make_surf_db(derivatives=DERIVATIVES, conditions=CONDITIONS,
 
     # fixed-effects activation images
     con_df = conditions
-    contrast_name = con_df.contrast
+    contrast_name = con_df.condition
     missing_images = []
     for subject in tqdm(subject_list):
         for i in range(len(con_df)):


### PR DESCRIPTION
This PR aims to solve #37, given that we recently polished the [ibc_conditions](https://github.com/individual-brain-charting/public_analysis_code/blob/master/ibc_data/ibc_conditions.tsv) file with all descriptions and for all tasks, it would make more sense to just keep this one file and maintain it as the reference.
Once this is reviewed, I can go on and remove the `conditions.tsv`. 