### PR TITLE
wm and harriri AOMIC to main_contrasts

### DIFF
--- a/ibc_data/main_contrasts.tsv
+++ b/ibc_data/main_contrasts.tsv
@@ -327,6 +327,7 @@ OptimismBias	future_vs_past
 OptimismBias	positive_vs_negative
 OptimismBias	future_positive_vs_negative
 OptimismBias	past_positive_vs_negative
+HarririAomic	emotion-shape
 FacesAomic	all-neutral
 FacesAomic	anger-neutral
 FacesAomic	contempt-neutral
@@ -337,6 +338,8 @@ FacesAomic	female-male
 StroopAomic	congruent-incongruent
 StroopAomic	incongruent-congruent
 StroopAomic	face_male-face_female
+WMAomic	active_change-active_no_change
+WMAomic	active-passive
 LocalizerAbstraction	localizer_checkerboards-other
 LocalizerAbstraction	localizer_faces-other
 LocalizerAbstraction	localizer_humanbody-other


### PR DESCRIPTION
Turns out we don't have any contrasts from **HarririAomic** and **WMAomic** listed on `main_contrasts`.
I'm suggesting to add *emotion-shape* from HarririAomic, and from WM I'd like to add *active-passive* and
*active_change-active_no_change*. Contrast maps seem to be interesting. 
See whole list of contrast [here](https://github.com/individual-brain-charting/public_analysis_code/blob/b9cee401c52a92e692d62b41172735d9000471d1/ibc_data/all_contrasts.tsv#L624).