### PR TITLE
Adding movie and rest as contrasts

### DIFF
--- a/ibc_public/utils_contrasts.py
+++ b/ibc_public/utils_contrasts.py
@@ -529,6 +529,8 @@ def mdtb(design_matrix_columns):
                       'tom_photo', 'tom_belief', ####
                       'search_easy', 'search_hard',  ####
                       'flexion_extension',
+                      'movie',
+                      'rest',
                       'action_action-control',
                       'finger_complex-simple',
                       'semantic_hard-easy',


### PR DESCRIPTION
From #86, I would like to model the *movie* and *rest* conditions from the MDTB runs.
The event files already take into account this trials. see [example](https://github.com/individual-brain-charting/analysis_pipeline/blob/master/ibc_main/neurospin_data/info/sub-04/mdtb_emotion/task-mdtb_sub-04_run-01_events.tsv). 