### PR TITLE
Adding movie condition and contrast to MDTB

### DIFF
--- a/ibc_data/all_contrasts.tsv
+++ b/ibc_data/all_contrasts.tsv
@@ -731,6 +731,7 @@ MDTB	tom_belief	believes	fixation	statement relates to character's believes	['se
 MDTB	search_easy	easy to find correct shape	fixation	easy to look for the right-oriented shape	['visual_search','visual_localization','salience','response_execution','response_selection']
 MDTB	search_hard	hard to find correct shape	fixation	hard to look for the right-oriented shape	['visual_search','visual_localization','visual_form_discrimination','task_difficulty','response_execution','response_selection']
 MDTB	flexion_extension	toes flexion-extension	fixation	continuous toes flexion-extension	['response_execution','left_toe_response_execution','right_toe_response_execution']
+MDTB	movie	movie watching	fixation	watching an animated movie without sound	['naturalistic_scenes','emotional_expression','visual_scene_perception']
 MDTB	action_action-control	hands making knot	resulting knot from different angles	hands making specific knot vs resulting knot	['action_perception','procedural_memory','action-outcome_learning','shape_recognition','task_difficulty','naturalistic_biological_motion']
 MDTB	finger_complex-simple	hard button sequence	easy button sequence	hard vs easy button sequence	['motor_control','task_difficulty']
 MDTB	semantic_hard-easy	ambiguous sequence	natural sequence	ambiguous vs natural sequence	['combinatorial_semantics','task_difficulty']

--- a/ibc_data/contrasts/MDTB.csv
+++ b/ibc_data/contrasts/MDTB.csv
@@ -1,14 +1,15 @@
-condition,action_action,action_control,finger_simple,finger_complex,semantic_hard,semantic_easy,2back_easy,2back_hard,tom_photo,tom_belief,search_easy,search_hard,flexion_extension,action_action-control,finger_complex-simple,semantic_hard-easy,2back_hard-easy,tom_belief-photo,search_hard-easy
-search_easy,,,,,,,,,,,1,,,,,,,,-1
-search_hard,,,,,,,,,,,,1,,,,,,,1
-action_action,1,,,,,,,,,,,,,1,,,,,
-action_control,,1,,,,,,,,,,,,-1,,,,,
-flexion_extension,,,,,,,,,,,,,1,,,,,,
-finger_complex,,,,1,,,,,,,,,,,1,,,,
-finger_simple,,,1,,,,,,,,,,,,-1,,,,
-tom_belief,,,,,,,,,,1,,,,,,,,1,
-tom_photo,,,,,,,,,1,,,,,,,,,-1,
-2back_easy,,,,,,,1,,,,,,,,,,-1,,
-2back_hard,,,,,,,,1,,,,,,,,,1,,
-semantic easy,,,,,,1,,,,,,,,,,-1,,,
-semantic hard,,,,,1,,,,,,,,,,,1,,,
+condition,action_action,action_control,finger_simple,finger_complex,semantic_hard,semantic_easy,2back_easy,2back_hard,tom_photo,tom_belief,search_easy,search_hard,flexion_extension,action_action-control,finger_complex-simple,semantic_hard-easy,2back_hard-easy,tom_belief-photo,search_hard-easy,movie
+search_easy,,,,,,,,,,,1,,,,,,,,-1,
+search_hard,,,,,,,,,,,,1,,,,,,,1,
+action_action,1,,,,,,,,,,,,,1,,,,,,
+action_control,,1,,,,,,,,,,,,-1,,,,,,
+flexion_extension,,,,,,,,,,,,,1,,,,,,,
+finger_complex,,,,1,,,,,,,,,,,1,,,,,
+finger_simple,,,1,,,,,,,,,,,,-1,,,,,
+tom_belief,,,,,,,,,,1,,,,,,,,1,,
+tom_photo,,,,,,,,,1,,,,,,,,,-1,,
+2back_easy,,,,,,,1,,,,,,,,,,-1,,,
+2back_hard,,,,,,,,1,,,,,,,,,1,,,
+semantic easy,,,,,,1,,,,,,,,,,-1,,,,
+semantic hard,,,,,1,,,,,,,,,,,1,,,,
+movie,,,,,,,,,,,,,,,,,,,,1

--- a/ibc_data/ibc_conditions.tsv
+++ b/ibc_data/ibc_conditions.tsv
@@ -431,6 +431,7 @@ MDTB	2back_easy	Easy 2-back trial, it is easy to remember whether the image was 
 MDTB	2back_hard	Hard 2-back trial, it is hard to remember whether the image was shown 2 images ago.
 MDTB	semantic_easy	Easy to decide whether the last word fits in the sentence, natural sequence
 MDTB	semantic_hard	Hard to decide whether the last word fits in the sentence, ambiguous sequence
+MDTB	movie	Watching a clip of an animated movie without sound
 Emotion	neutral_image	Block of neutral images
 Emotion	negative_image	Block of negative images
 Emotion	valence_scale	Subject’s rating of emotional state

--- a/ibc_data/main_contrasts.tsv
+++ b/ibc_data/main_contrasts.tsv
@@ -398,6 +398,7 @@ MDTB	tom_belief
 MDTB	search_easy
 MDTB	search_hard
 MDTB	flexion_extension
+MDTB	movie
 MDTB	action_action-control
 MDTB	finger_complex-simple
 MDTB	semantic_hard-easy


### PR DESCRIPTION
From #86, we generated a movie map, now we have to annotate it and include it in the rest of the lists.
@bthirion do you agree with the annotations? I am including 3 for now
`naturalistic_scenes`: refers to passive viewing of scenes and cartoons
`emotional_expression`: the movie has a high emotional loading
`visual_scene_perception`: the scenario changes continuously, different landscapes and elements

We could also add `face_perception` but I hesitate since the map is modelling the whole 30 seconds of the trial, and the 30 seconds are not all about faces.
Also `social_cognition` is an option, but it's be a bit more related to the content of the clips. 